### PR TITLE
Patch 1 (#239)

### DIFF
--- a/core/Container/Theme_Options_Container.php
+++ b/core/Container/Theme_Options_Container.php
@@ -267,6 +267,7 @@ class Theme_Options_Container extends Container {
 	 * the theme options file name.
 	 **/
 	protected function clear_string( $string ) {
+		$string = apply_filters( 'sanitize_file_name', $string );
 		return preg_replace( array( '~ +~', '~[^\w\d-]+~u', '~-+~' ), array( '-', '-', '-' ), strtolower( remove_accents( $string ) ) );
 	}
 }


### PR DESCRIPTION
Add filter "sanitize_file_name" to theme options container file parameter.

This fixes non-latin titles for options page script name. Titles converting in latin chars when using plug-ins for the translation in latin (cyr2lat, etc.)